### PR TITLE
Correct the Website next app folder name

### DIFF
--- a/Indexing-Contract-Data-TheGraph.md
+++ b/Indexing-Contract-Data-TheGraph.md
@@ -260,11 +260,11 @@ First, You would need to create a new `next` app. Your folder structure should l
    - RandomWinnerGame
        - graph
        - hardhat-tutorial
-       - next-app
+       - my-app
        - abi.json
 ```
 
-To create this `next-app`, in the terminal point to RandomWinnerGame folder and type
+To create this `my-app`, in the terminal point to RandomWinnerGame folder and type
 
 ```bash
     npx create-next-app@latest


### PR DESCRIPTION
By default, the name is `my-app` instead of `next-app`.