### PR TITLE
Fixing Error That Appears In Terminal

### DIFF
--- a/Local-Blockchain.md
+++ b/Local-Blockchain.md
@@ -66,6 +66,9 @@ contract Greeter {
         console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
         greeting = _greeting;
     }
+    
+    receive() external payable{}
+    fallback() external payable{}
 }
 
 ```
@@ -151,6 +154,9 @@ contract Greeter {
         console.log("Changing greeting from '%s' to '%s'", greeting, _greeting);
         greeting = _greeting;
     }
+    
+    receive() external payable{}
+    fallback() external payable{}
 }
 
 ```


### PR DESCRIPTION
When you do `npx hardhat run scripts/deploy.js --network localhost`
The error shows this when calling the setGreeting function on Remix:
<img width="1072" alt="Screenshot 2023-01-03 at 3 05 35 PM" src="https://user-images.githubusercontent.com/85313109/210442876-b5dc41f1-6922-413d-b6d3-5e80d5acca99.png">

According to the error, it throws it because there is no fallback function. So by adding this to your solidity code:
```Solidity
receive() external payable{}
fallback() external payable{}
```
The terminal will spit out something like this instead: <img width="1198" alt="Screenshot 2023-01-03 at 2 55 14 PM" src="https://user-images.githubusercontent.com/85313109/210439982-42048520-a63c-4293-bb63-b1206ae1e932.png">
