### PR TITLE
Removing extra slash

### DIFF
--- a/IPFS-Practical.md
+++ b/IPFS-Practical.md
@@ -225,7 +225,7 @@ require("dotenv").config({ path: ".env" });
 
 async function main() {
   // URL from where we can extract the metadata for a LW3Punks
-  const metadataURL = "ipfs://YOUR-METADATA-CID/";
+  const metadataURL = "ipfs://YOUR-METADATA-CID";
   /*
   A ContractFactory in ethers.js is an abstraction used to deploy new smart contracts,
   so lw3PunksContract here is a factory for instances of our LW3Punks contract.


### PR DESCRIPTION
The extra slash was causing an issue in terms of completing the level, even after minting an NFT and the metadata showing up correctly on Opensea.