### PR TITLE
feat: add check in contract to validate maxplayers input

### DIFF
--- a/Lottery-Game-Chainlink-VRF.md
+++ b/Lottery-Game-Chainlink-VRF.md
@@ -155,6 +155,8 @@ contract RandomWinnerGame is VRFConsumerBase, Ownable {
     function startGame(uint8 _maxPlayers, uint256 _entryFee) public onlyOwner {
         // Check if there is a game already running
         require(!gameStarted, "Game is currently running");
+        // Check if _maxPlayers is greater than 0
+        require(_maxPlayers > 0, "You cannot create a game with max players limit equal 0");
         // empty the players array
         delete players;
         // set the max players for this game


### PR DESCRIPTION
I add a check in the contract to validate if __maxPlayers_ input in _startGame_ function is greater than 0.
Because otherwise by creating a game with a maximum player limit of 0, it becomes impossible to join and therefore find a winner.
The contract becomes unusable.
